### PR TITLE
Update Protocols for a PDFRenderer to conform to

### DIFF
--- a/MinitexPDFProtocols/MinitexPDFProtocols.swift
+++ b/MinitexPDFProtocols/MinitexPDFProtocols.swift
@@ -9,67 +9,90 @@
 import Foundation
 import UIKit
 
-// the items that are marked required are needed to
-// recreate an annotation in PSPDFKit later
-@objc public class MinitexPDFAnnotation: NSObject, Codable {
-  // required
-  public let pageIndex: UInt
-  // required
-  public let type: String
-  // required
-  public let bbox: String
-  // required
-  public let rects: [String]
 
-  // optional
-  public let color: String?
-  // optional
-  public let opacity: Float?
-  // optional
-  // we store this in case the field parsing fails, then we have the original JSON
-  public let JSONData: Data?
+/// A generic annotation in a PDF document.
+@objc public protocol MinitexPDFAnnotation: class {
+  /// An annotation must belong to one page of the PDF document.
+  var page: MinitexPDFPage { get }
 
-  // optional
-  // this value cannot be set in PSPDFKit
-  //var v: Int?
-
-  public init(pageIndex: UInt, type: String, bbox: String, rects: [String],
-              color: String?, opacity: Float?, JSONData: Data?) {
-    self.pageIndex = pageIndex
-    self.type = type
-    self.bbox = bbox
-    self.rects = rects
-    self.color = color
-    self.opacity = opacity
-    self.JSONData = JSONData
-  }
+  /// Complex annotations may be fully described by something like JSON from a particular
+  /// renderer. This allows easy access by the host to a version it can store or sync.
+  var serializedRepresentation: Data { get }
 }
 
-
+/// The View Controller for the PDF document.
 @objc public protocol MinitexPDFViewController: class {
-  // we have to pass in a dictionary because @objc protocol function
-  // cannot accept multiple parameters
-  @objc init(dictionary: [String: Any])
+  /// The host can optionally set a delegate object to listen for certain events.
+  var delegate: MinitexPDFViewControllerDelegate? { get set }
+
+  /// Initialize a view controller with a particular PDF document.
+  ///
+  /// - Parameters:
+  ///   - file: The local file directory of the PDF document.
+  ///   - page: An optional page to navigate to when first opening.
+  ///   - bookmarks: Any additional user-saved bookmarks.
+  ///   - annotations: Any additional user-created generic annotations.
+  init?(file: URL,
+        openToPage page: MinitexPDFPage?,
+        bookmarks: [MinitexPDFPage]?,
+        annotations: [MinitexPDFAnnotation]?)
 }
 
+/// A page in a PDF document.
+@objc public protocol MinitexPDFPage: class {
+  /// A PDF document must have an unsigned integer represenation of its pages.
+  var pageNumber: UInt { get }
+}
 
 @objc public protocol MinitexPDFViewControllerDelegate: class {
-  @objc func userDidNavigate(page: Int)
-  @objc func saveBookmarks(pageNumbers: [UInt])
-  @objc func saveAnnotations(annotations: [MinitexPDFAnnotation])
-  @objc func willMoveToMinitexParentController(parent: UIViewController?)
+  /// Called when a page of the PDF document becomes the new presented page
+  /// visible on screen.
+  ///
+  /// - Parameter page: The page being presented on screen.
+  func userDidNavigate(toPage page: MinitexPDFPage)
+  /// Called when a user selects to create a bookmark for a specific page.
+  ///
+  /// - Parameter bookmark: The specific page the user has selected to save as a
+  ///   bookmark.
+  func userDidCreate(bookmark: MinitexPDFPage)
+  /// Called when a user selects to delete a bookmark for a specific page.
+  ///
+  /// - Parameter bookmark: The specific page the user has selected to delete.
+  func userDidDelete(bookmark: MinitexPDFPage)
+  /// Called when a user selects to create a generic annotation for a specific page.
+  ///
+  /// - Parameter bookmark: The specific generic annotation the user has selected to save as a
+  ///   bookmark.
+  func userDidCreate(annotation: MinitexPDFAnnotation)
+  /// Called when a user selects to delete a generic annotation for a specific page.
+  ///
+  /// - Parameter bookmark: The specific generic annotation the user has selected to delete.
+  func userDidDelete(annotation: MinitexPDFAnnotation)
 }
 
+//MARK: -
+//MARK: Factory Methods
 
-@objc public class MinitexPDFViewControllerFactory: NSObject {
-  @objc public static func createPDFViewController(dictionary: [String: Any]) -> MinitexPDFViewController? {
+@objcMembers public class MinitexPDFViewControllerFactory: NSObject {
+  /// The API host must create a View Controller for the PDF from a static factory method.
+  ///
+  /// - Parameters:
+  ///   - fileUrl: The local file directory of the PDF document.
+  ///   - page: An optional page to navigate to when first opening.
+  ///   - bookmarks: Any additional user-saved bookmarks.
+  ///   - annotations: Any additional user-created generic annotations.
+  /// - Returns: An instance of MinitexPDFViewController, or nil if something failed.
+  public static func create(fileUrl: URL,
+                            openToPage page: MinitexPDFPage?,
+                            bookmarks: [MinitexPDFPage]?,
+                            annotations: [MinitexPDFAnnotation]?) -> MinitexPDFViewController? {
 
-    guard let pdfViewControllerClass = NSClassFromString("PDF.PDFViewController")
-                                        as? MinitexPDFViewController.Type else {
-      return nil
+    // PDF renderer using a PSPDFKit license.
+    if let pdfViewControllerClass = NSClassFromString("PDF.PDFViewController") as? MinitexPDFViewController.Type {
+      return pdfViewControllerClass.init(file: fileUrl, openToPage: page, bookmarks: bookmarks, annotations: annotations)
+    } else {
+      // PDF renderer using Apple's PDFKit.
+      fatalError()  //placeholder
     }
-
-    let pdfViewController = pdfViewControllerClass.init(dictionary: dictionary)
-    return pdfViewController
   }
 }

--- a/MinitexPDFProtocols/MinitexPDFProtocols.swift
+++ b/MinitexPDFProtocols/MinitexPDFProtocols.swift
@@ -17,7 +17,15 @@ import UIKit
 
   /// Complex annotations may be fully described by something like JSON from a particular
   /// renderer. This allows easy access by the host to a version it can store or sync.
-  var serializedRepresentation: Data { get }
+  ///
+  /// - Returns: A data representation of the annotation, like from a JSON encoder.
+  func toData() -> Data
+
+  /// Conversely, an annotation should be able to be reconstructed from the serialized data.
+  ///
+  /// - Parameter data: The serialized data.
+  /// - Returns: An instance of an annotation.
+  static func fromData(_ data: Data) -> MinitexPDFAnnotation?
 }
 
 /// The View Controller for the PDF document.
@@ -39,9 +47,29 @@ import UIKit
 }
 
 /// A page in a PDF document.
-@objc public protocol MinitexPDFPage: class {
+@objcMembers public class MinitexPDFPage : NSObject, Codable {
   /// A PDF document must have an unsigned integer represenation of its pages.
-  var pageNumber: UInt { get }
+  let pageNumber: UInt
+
+  init(pageNumber: UInt) {
+    self.pageNumber = pageNumber
+  }
+
+  /// Complex annotations may be fully described by something like JSON from a particular
+  /// renderer. This allows easy access by the host to a version it can store or sync.
+  ///
+  /// - Returns: A data representation of the annotation, like from a JSON encoder.
+  public func toData() -> Data {
+    return try! JSONEncoder().encode(self)
+  }
+
+  /// Conversely, an annotation should be able to be reconstructed from the serialized data.
+  ///
+  /// - Parameter data: The serialized data.
+  /// - Returns: An instance of an annotation.
+  public class func fromData(_ data: Data) -> MinitexPDFPage? {
+    return try? JSONDecoder().decode(MinitexPDFPage.self, from: data)
+  }
 }
 
 @objc public protocol MinitexPDFViewControllerDelegate: class {


### PR DESCRIPTION
The following Pull Request is being made to create discussion on specific updates to the "PDFRendererProvider" set of Protocols.

At a high level:
1. Update init methods to describe exactly what is needed with required, typed parameters.
2. If a property or class contains data specific to one renderer, for example PSPDFKit, then move that out of the protocol definitions. Keep protocols confined to things that all renderers will require (will go into more detail).
3. Add header documentation that describes the expected usage of the public API.

Demo builds of "PDF-iOS", imported into SimplyE forks, represent a successful ability to launch and navigate PDF files using the third party PSPDFKit SDK. "PDF-iOS" represents one of potentially many "PDFRenderer's", which, by this set of protocols would be _provided_ to a host like SimplyE. This is successful work implemented by Vui N. and Paul S. of the Minitex partnership to NYPL and Library Simplified.

I recommend viewing these comments in the split-view "files changed" view.