### PR TITLE
SIMPLY-3536 Page number is incorrect for pdf book after book reopening

### DIFF
--- a/MinitexPDFProtocols/Book Reader/BookViewController.swift
+++ b/MinitexPDFProtocols/Book Reader/BookViewController.swift
@@ -82,12 +82,12 @@ class BookViewController: UIViewController, MinitexPDFViewController, UIPopoverP
         titleLabelContainer.layer.cornerRadius = 4
         pageNumberLabelContainer.layer.cornerRadius = 4
 
-        resume()
-
         if let firstPage = self.firstPage,
             let page = pdfView.document?.page(at: Int(firstPage)) {
             pdfView.go(to: page)
         }
+
+        resume()
 
         // Add observer last because setting `pdfView.displayMode` triggers `pdfViewPageChanged` and that depends on `resume()` to init things
         NotificationCenter.default.addObserver(self, selector: #selector(pdfViewPageChanged(_:)), name: .PDFViewPageChanged, object: nil)


### PR DESCRIPTION
**What's this do?**
Navigate to the last opened location in a *.pdf book before displaying labels. This fixes the issue when the app opens a .pdf on the last opened page, but shows page number 1.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3536

**How should this be tested? / Do these changes have associated tests?**
Run
```
./scripts/build-3rd-party-dependencies.sh
```
and follow the steps in **Acceptance Criteria** in the ticket.

**Does this include changes that require a new SimplyE build for QA?**
Yes

**Has the application documentation been updated for these changes?**
NA

**Did someone actually run this code to verify it works?**
@vladimirfedorov 